### PR TITLE
Merge Task 15 into Develop: Strip Task references from Effects

### DIFF
--- a/Assets/Examples/DataCommand/Effects/ChangeCounterEffect.cs
+++ b/Assets/Examples/DataCommand/Effects/ChangeCounterEffect.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using AIR.Fluxity;
 using UnityEngine;
 
@@ -11,10 +10,9 @@ namespace Examples.DataCommand
         {
         }
 
-        public override Task DoEffect(ChangeCountCommand command)
+        public override void DoEffect(ChangeCountCommand command)
         {
             Debug.Log($"Count changed by {command.Delta}.");
-            return Task.CompletedTask;
         }
     }
 }

--- a/Assets/Examples/Simple/Effects/DecrementCounterEffect.cs
+++ b/Assets/Examples/Simple/Effects/DecrementCounterEffect.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using AIR.Fluxity;
 using UnityEngine;
 
@@ -9,10 +8,9 @@ namespace Examples.Simple
         public DecrementCounterEffect(IDispatcher dispatcher)
             : base(dispatcher) { }
 
-        public override Task DoEffect(DecrementCountCommand command)
+        public override void DoEffect(DecrementCountCommand command)
         {
             Debug.Log("Decrement Command made.");
-            return Task.CompletedTask;
         }
     }
 }

--- a/Assets/Examples/Simple/Effects/IncrementCounterEffect.cs
+++ b/Assets/Examples/Simple/Effects/IncrementCounterEffect.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using AIR.Fluxity;
 using UnityEngine;
 
@@ -9,10 +8,9 @@ namespace Examples.Simple
         public IncrementCounterEffect(IDispatcher dispatcher)
             : base(dispatcher) { }
 
-        public override Task DoEffect(IncrementCountCommand command)
+        public override void DoEffect(IncrementCountCommand command)
         {
             Debug.Log("Increment Command made.");
-            return Task.CompletedTask;
         }
     }
 }

--- a/Packages/Fluxity/Runtime/Dispatcher.cs
+++ b/Packages/Fluxity/Runtime/Dispatcher.cs
@@ -1,15 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using AIR.Flume;
 
 namespace AIR.Fluxity
 {
-    public class Dispatcher : Dependent, IDispatcher, IDisposable
+    public class Dispatcher : Dependent, IDispatcher
     {
         private readonly Dictionary<Type, List<IEffect>> _effects = new Dictionary<Type, List<IEffect>>();
-        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
         private bool _isReducing;
         private IStore _store;
 
@@ -31,9 +28,6 @@ namespace AIR.Fluxity
         public void Dispatch<TCommand>(TCommand command)
             where TCommand : ICommand
         {
-            if (_cancellationTokenSource.IsCancellationRequested)
-                return;
-
             if (_isReducing)
                 throw new DispatcherException($"Attempted to dispatch '{command.GetType()}' during an existing {nameof(Dispatch)}.");
 
@@ -44,58 +38,14 @@ namespace AIR.Fluxity
             ProcessEffects(command);
         }
 
-        public void Dispose()
-        {
-            _cancellationTokenSource.Cancel();
-        }
-
         private void ProcessEffects<TCommand>(TCommand command)
             where TCommand : ICommand
         {
-            var effectTasks = new List<Task>();
-            var exceptions = new List<Exception>();
-            effectTasks.Capacity = _effects.Count;
+            if (!_effects.TryGetValue(typeof(TCommand), out var extantEffects))
+                return;
 
-            if (_effects.TryGetValue(typeof(TCommand), out var extantEffects))
-            {
-                foreach (var effect in extantEffects)
-                {
-                    try
-                    {
-                        var t = effect.DoEffect(command);
-                        if (t.IsCompleted)
-                            continue;
-
-                        effectTasks.Add(Task.Run(async () => await t, _cancellationTokenSource.Token));
-                    }
-                    catch (Exception e)
-                    {
-                        exceptions.Add(e);
-                    }
-                }
-            }
-
-            if (exceptions.Count > 0)
-                throw new AggregateException(exceptions);
-
-            exceptions.Clear();
-            if (effectTasks.Count > 0)
-            {
-                Task.Run(async () =>
-                {
-                    try
-                    {
-                        await Task.WhenAll(effectTasks);
-                    }
-                    catch (Exception e)
-                    {
-                        exceptions.Add(e);
-                    }
-
-                    if (exceptions.Count > 0)
-                        throw new AggregateException(exceptions);
-                });
-            }
+            foreach (var effect in extantEffects)
+                effect.DoEffect(command);
         }
     }
-} 
+}

--- a/Packages/Fluxity/Runtime/Effect.cs
+++ b/Packages/Fluxity/Runtime/Effect.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using AIR.Flume;
 
 namespace AIR.Fluxity
@@ -11,9 +10,9 @@ namespace AIR.Fluxity
 
         protected IDispatcher Dispatcher { get; private set; }
 
-        public abstract Task DoEffect(TCommand command);
+        public abstract void DoEffect(TCommand command);
 
-        public Task DoEffect(ICommand command)
+        public void DoEffect(ICommand command)
             => DoEffect((TCommand)command);
     }
 }

--- a/Packages/Fluxity/Runtime/Interfaces/IEffect.cs
+++ b/Packages/Fluxity/Runtime/Interfaces/IEffect.cs
@@ -1,15 +1,13 @@
-using System.Threading.Tasks;
-
 namespace AIR.Fluxity
 {
     public interface IEffect<TCommand> : IEffect
         where TCommand : ICommand
     {
-        Task DoEffect(TCommand command);
+        void DoEffect(TCommand command);
     }
 
     public interface IEffect
     {
-        Task DoEffect(ICommand command);
+        void DoEffect(ICommand command);
     }
 }

--- a/Packages/Fluxity/Tests/DummyTypes/DummyDelegateEffect.cs
+++ b/Packages/Fluxity/Tests/DummyTypes/DummyDelegateEffect.cs
@@ -13,10 +13,9 @@ namespace AIR.Fluxity.Tests.DummyTypes
             _customAction = customAction;
         }
 
-        public override Task DoEffect(DummyCommand command)
+        public override void DoEffect(DummyCommand command)
         {
             _customAction?.Invoke();
-            return Task.CompletedTask;
         }
     }
 }

--- a/Packages/Fluxity/Tests/DummyTypes/DummyEffect.cs
+++ b/Packages/Fluxity/Tests/DummyTypes/DummyEffect.cs
@@ -1,6 +1,4 @@
-﻿using System.Threading.Tasks;
-
-namespace AIR.Fluxity.Tests.DummyTypes
+﻿namespace AIR.Fluxity.Tests.DummyTypes
 {
     internal class DummyEffect : Effect<DummyCommand>
     {
@@ -11,10 +9,9 @@ namespace AIR.Fluxity.Tests.DummyTypes
         {
         }
 
-        public override Task DoEffect(DummyCommand command)
+        public override void DoEffect(DummyCommand command)
         {
             accumPayload += command.payload;
-            return Task.CompletedTask;
         }
     }
 }

--- a/Packages/Fluxity/Tests/PresenterFlumeIntegrationUnityTests.cs
+++ b/Packages/Fluxity/Tests/PresenterFlumeIntegrationUnityTests.cs
@@ -93,10 +93,9 @@ public class PresenterFlumeIntegrationUnityTests
 
         public void Inject(IDummyService dummyService) => _dummyService = dummyService;
 
-        public override Task DoEffect(DummyCommand command)
+        public override void DoEffect(DummyCommand command)
         {
             _dummyService.LastSignal = command.payload;
-            return Task.CompletedTask;
         }
     }
 


### PR DESCRIPTION
<!-- title as 'Merge <Source identifier> into <Parent identifier>: <Source description>' -->
## Summary
<!-- A clear and concise summary (1-2 sentences) of changes made. -->
Effects would return Tasks in order to potentially perform asynchronous processes, but this restricts platform usage (e.g. WebGL doesn't support async Tasks when built from Unity), as well as adding clutter on synchronous tasks (requiring return of `Task.CompletedTask` on every non-async Effect).

This removes Task references, making Fluxity async solution agnostic, and moving the onus of exception reporting to the Effect implementation instead of the Dispatcher.

## Closes
<!-- add task issue links to close here, e.g. #123 -->
closes #15 

## Details
<!-- A more in-depth listing of changes made. -->

- Stripped Task references in regards to Effects

## Screenshots
<!-- If applicable, add screenshots to help explain changes made. -->

## Additional context
<!-- Add any other context relating to the PR here. -->
