### PR TITLE
Merge 47_storewindow-decimal-support into main: Show decimals correctly in store window

### DIFF
--- a/Assets/Examples/StoresWindow/StoreWindowStates.cs
+++ b/Assets/Examples/StoresWindow/StoreWindowStates.cs
@@ -41,6 +41,8 @@ namespace Examples.StoresWindow
         public System.Guid guid;
         public System.DateTime dateTime;
         public System.TimeSpan timeSpan;
+        public long i64;
+        public decimal dec;
     }
 
     public struct TransformsState

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FluxityFlumeRegisterContext and FluxityFeatureContext. Used during Fluxity setup to move this logic out into it's own location.
 - `FeatureAggregateObserver`, mechanism for bundling change notification from multiple sources. Replacing that use case previously in `Presenter`.
 - Effects can now be set up in a similar way to Feature, Reducer binding.
+- Correctly show `decimal` type values in the StoresWindow.
 
 ### Changed
 

--- a/Packages/Fluxity/Editor/ObjectWalker.cs
+++ b/Packages/Fluxity/Editor/ObjectWalker.cs
@@ -129,19 +129,20 @@ namespace AIR.Fluxity.Editor
         private bool IsLeafType(object obj)
         {
             if (obj.GetType().IsPrimitive
-                || obj.GetType().IsEnum
-                || obj is UnityEngine.Object)
+                || obj.GetType().IsEnum)
                 return true;
 
             switch (obj)
             {
             case string:
+            case decimal:
             case Vector2:
             case Vector3:
             case Vector4:
             case System.Guid:
             case System.DateTime:
             case System.TimeSpan:
+            case UnityEngine.Object:
                 return true;
             default:
                 return false;


### PR DESCRIPTION
<!-- title as 'Merge <Source identifier> into <Parent identifier>: <Source description>'
 E.g. Merge 27_header-styles into main: Update Header colours to match style guide -->
## Summary
<!-- A clear and concise summary of changes made. 1-2 sentences. -->
decimal will show up in usage when a store maps to some db or very large number and we want to show it for inspection.

## Closes
<!-- Add task issue links to close here, e.g. #123 
There should always be at least one of these. -->
closes #47 

## Screenshots
<!-- If applicable, add screenshots to help explain changes made.  If none, remove this section. -->
![image](https://github.com/ActuatorDigital/Fluxity/assets/4897812/72943bc8-4fd3-44b5-8889-3b4cff2bcebb)

## Project Health
<!-- This section is especially important when merging into main or similar. 
All relevant items that are not ticked should be addressed in either the Details or Additional context section.
Remove any lines that do not apply. -->
- [x] Changelog updated.