### PR TITLE
Merge 54 into main: Feature Handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FeatureAggregateObserver`, mechanism for bundling change notification from multiple sources. Replacing that use case previously in `Presenter`.
 - Effects can now be set up in a similar way to Feature, Reducer binding.
 - Correctly show `decimal` type values in the StoresWindow.
+- Added FeatureHandle for when full observer functionality in FeatureObserver is not needed, e.g. just needing feature value.
 
 ### Changed
 

--- a/Packages/Fluxity/Runtime/Utility/FeatureHandle.cs
+++ b/Packages/Fluxity/Runtime/Utility/FeatureHandle.cs
@@ -1,0 +1,17 @@
+using AIR.Flume;
+
+namespace AIR.Fluxity
+{
+    public sealed class FeatureHandle<TState> : Dependent, IFeatureView<TState>
+        where TState : struct
+    {
+        private IFeatureObservable<TState> _feature;
+
+        public TState State => _feature.State;
+
+        public void Inject(IStore store)
+        {
+            _feature = store.GetFeatureObservable<TState>();
+        }
+    }
+}

--- a/Packages/Fluxity/Runtime/Utility/FeatureHandle.cs.meta
+++ b/Packages/Fluxity/Runtime/Utility/FeatureHandle.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3d58c1b46b4f46f48c183fec01eefb0d
+timeCreated: 1729227960

--- a/Packages/Fluxity/Tests/FeatureHandleTests.cs
+++ b/Packages/Fluxity/Tests/FeatureHandleTests.cs
@@ -1,0 +1,28 @@
+using AIR.Fluxity;
+using AIR.Fluxity.Tests.DummyTypes;
+using NUnit.Framework;
+
+public class FeatureHandleTests
+{
+    private IStore _store;
+    private Feature<DummyState> _feature;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _store = new Store();
+        _feature = new Feature<DummyState>(default);
+        _store.AddFeature(_feature);
+    }
+
+    [Test]
+    public void State_WhenFeatureStateUpdates_ShouldHaveExpectedValue()
+    {
+        const int EXPECTED = 5;
+        var handle = new FeatureHandle<DummyState>();
+        handle.Inject(_store);
+
+        _feature.SetState(new DummyState { value = EXPECTED });
+        Assert.AreEqual(EXPECTED, handle.State.value);
+    }
+}

--- a/Packages/Fluxity/Tests/FeatureHandleTests.cs.meta
+++ b/Packages/Fluxity/Tests/FeatureHandleTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2e961c9f34b945088cdffcf989f0d490
+timeCreated: 1729228130

--- a/Packages/Fluxity/Tests/FeatureObserverTests.cs
+++ b/Packages/Fluxity/Tests/FeatureObserverTests.cs
@@ -1,6 +1,7 @@
 ﻿using AIR.Fluxity;
 using AIR.Fluxity.Tests.DummyTypes;
 using NUnit.Framework;
+
 public class FeatureObserverTests
 {
     private IStore _store;

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ FeatureObserver allows for registering on state change or at will polling of the
 
 The FeatureObserverAggregate is designed for the special case where you want to route the callback from a number of Features all to the same `Action`.
 
+FeatureHandle is the stripped-down version for when you just want to poll the state of the feature, and don't need on state change callbacks.
+
 ### Views
 
 Fluxity does not explicitly implement any Views, as the form the view takes is entirely dependent on the type of Unity


### PR DESCRIPTION
<!-- title as 'Merge <Source identifier> into <Parent identifier>: <Source description>'
 E.g. Merge 27_header-styles into main: Update Header colours to match style guide -->
## Summary
<!-- A clear and concise summary of changes made. 1-2 sentences. -->
Adds `FeatureHandle` class, a stripped-down version of `FeatureObserver` for use in cases where on change events aren't needed, such as one-off checks or pure polls.

## Closes
<!-- Add task issue links to close here, e.g. #123 
There should always be at least one of these. -->
closes #54

## Details
<!-- A more in-depth listing of changes made. If none, remove this section. 
This section is to aid the reviewer by increasing their understanding of what was done and
how they can review the changes. If the changes are trivial, remove the section. -->

- `FeatureHandle` does not subscribe to feature on change events, and so does not need to be an `IDisposable`.

## Project Health
<!-- This section is especially important when merging into main or similar. 
All relevant items that are not ticked should be addressed in either the Details or Additional context section.
Remove any lines that do not apply. -->
- [x] Unit Tests run and pass.

